### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ const references = [];
 const ast = parse(`var a = b.c;`);
 
 walk(ast, {
-	enter(node, parent) {
+	enter(node, parent, prop) {
 		if (node.type === 'Identifier') identifiers.push(node);
-		if (is_reference(node, parent)) references.push(node);
+		if (prop !== 'init' && is_reference(node, parent)) references.push(node);
 	}
 });
 


### PR DESCRIPTION
Before modification, `references` contain `MemberExpression`, so the output value of the following code should be `a, undefiled,c`. 