### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
 	"version": "3.0.2",
 	"description": "Determine whether an AST node is a reference",
 	"type": "module",
-	"module": "src/index.js",
 	"types": "types/index.d.ts",
 	"exports": {
 		"types": "./types/index.d.ts",
-		"import": "./src/index.js"
+		"default": "./src/index.js"
 	},
 	"files": [
 		"src",


### PR DESCRIPTION
- `module` is ignored so can be removed
- `default` is gives better error messages than `import` if you use it wrong