### PR TITLE
Fix: Check for `MetaProperty`s (eg `import.meta`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,10 @@ export default function is_reference (node, parent) {
 
 			// disregard the `foo` in `class {foo(){}}` but keep it in `class {[foo](){}}`
 			case 'MethodDefinition': return parent.computed;
-
+				
+			//disregard the `meta` in `import.meta`
+			case 'MetaProperty': return parent.meta === node;
+				
 			// disregard the `foo` in `class {foo=bar}` but keep it in `class {[foo]=bar}` and `class {bar=foo}`
 			case 'PropertyDefinition': return parent.computed || node === parent.value;
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default function is_reference (node, parent) {
 			// disregard the `foo` in `class {foo(){}}` but keep it in `class {[foo](){}}`
 			case 'MethodDefinition': return parent.computed;
 				
-			//disregard the `meta` in `import.meta`
+			// disregard the `meta` in `import.meta`
 			case 'MetaProperty': return parent.meta === node;
 				
 			// disregard the `foo` in `class {foo=bar}` but keep it in `class {[foo]=bar}` and `class {bar=foo}`

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -70,6 +70,8 @@ const negative = {
 
 	'class field': `
 		class Bar { foo = 1; }`,
+	'meta property': `
+		import.meta`,
 };
 
 function findFooReferences(code) {


### PR DESCRIPTION
Fixes #20. Now, the `meta` in `import.meta` will return `false` because it is not a reference. This adds tests for `MetaProperty`s as well. 