### PR TITLE
target es2020, since the package now uses optional chaining

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"allowJs": true,
 		"checkJs": true,
 		"strict": true,
-		"target": "es2017",
+		"target": "es2020",
 		"module": "node16",
 		"declaration": true,
 		"emitDeclarationOnly": true,


### PR DESCRIPTION
[This change](https://github.com/Rich-Harris/is-reference/commit/42f240cb39d49bd28649bae414226e2e09c251e9#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R21) introduced optional chaining syntax, which is only available from ES2020[1]

Right now, pre-es2020 projects can still resolve `is-reference` to `3.0.3`, and fail.

[1] https://262.ecma-international.org/11.0/index.html#prod-OptionalChain